### PR TITLE
Rotate axis 4 about 180 degree

### DIFF
--- a/kuka_kr210_support/urdf/kr210r2700extra_macro.xacro
+++ b/kuka_kr210_support/urdf/kr210r2700extra_macro.xacro
@@ -62,13 +62,13 @@
     </link>
     <link name="${prefix}link_4">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin xyz="0 0 0" rpy="${180 * DEG2RAD} 0 0"/>
         <geometry>
           <mesh filename="package://kuka_kr210_support/meshes/kr210r2700extra/visual/link_4.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin xyz="0 0 0" rpy="${180 * DEG2RAD} 0 0"/>
         <geometry>
           <mesh filename="package://kuka_kr210_support/meshes/kr210r2700extra/collision/link_4.stl" />
         </geometry>


### PR DESCRIPTION
Simple pull request. The axis 4 is oddly positioned, overlapping the axis 5. A small rotation of 180 is just enough to avoid that. 